### PR TITLE
Remove GitHub references from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Scientific Quran Evidence
 
-[![Documentation Status](https://github.com/SaurikS1/Ayatology/actions/workflows/deploy.yml/badge.svg)](https://sauriks1.github.io/Ayatology/)
 
 A modern documentation project exploring scientific phenomena mentioned in the Quran and their correlation with modern scientific discoveries.
 
@@ -9,7 +8,7 @@ A modern documentation project exploring scientific phenomena mentioned in the Q
 
 ## 🌐 Website
 
-Visit our documentation at: [https://sauriks1.github.io/Ayatology/](https://sauriks1.github.io/Ayatology/)
+Visit our documentation at: [https://ayatology.example.com](https://ayatology.example.com)
 
 ## 📚 Topics Covered
 
@@ -30,7 +29,7 @@ We welcome contributions from researchers, scholars, and anyone interested in ex
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/SaurikS1/Ayatology.git
+   git clone https://example.com/Ayatology.git
    ```
 
 2. Install dependencies:

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,4 +14,4 @@ This documentation is organized into several key areas:
 
 Navigate through the sections using the sidebar to explore specific topics. Each section provides detailed analysis supported by scientific references and Quranic verses.
 
-For suggestions or contributions, please visit our [GitHub repository](https://github.com/SaurikS1/Ayatology).
+We welcome suggestions and contributions—feel free to reach out to the team.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,5 @@
 site_name: Scientific Quran Evidence
-site_url: https://SaurikS1.github.io/Ayatology
-repo_name: SaurikS1/Ayatology
-repo_url: https://github.com/SaurikS1/Ayatology
+site_url: https://ayatology.example.com
 
 theme:
   name: material
@@ -71,9 +69,6 @@ extra:
     property: G-PLACEHOLDER
   version:
     provider: mike
-  social:
-    - icon: fontawesome/brands/github
-      link: https://github.com/SaurikS1/Ayatology
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary
- drop references to GitHub from MkDocs configuration
- refresh landing page text
- remove GitHub links from README

## Testing
- `mkdocs build --strict` *(fails: command not found)*